### PR TITLE
[#2] Updated contributors mapping

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -25,6 +25,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="dataset_version_issued" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:DateIssued"></xsl:variable>
   <xsl:variable name="dataset_direct_access" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:DirectAccessURI"></xsl:variable>
   <xsl:variable name="ipr_statement" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Citations/abcd:Citation/abcd:Text"></xsl:variable>
+  <!-- TODO: dataset_uri is probably redundant to dataset_url and can be removed -->
   <xsl:variable name="dataset_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Description/abcd:Representation/abcd:URI"></xsl:variable>
   <xsl:variable name="terms_of_use" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:TermsOfUseStatements/abcd:TermsOfUse"></xsl:variable>
   <xsl:variable name="licence" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Licenses/abcd:License"></xsl:variable>
@@ -43,6 +44,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
   
+  <xsl:variable name="gathering_agents" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:GatheringAgents/abcd:GatheringAgent"></xsl:variable>
 
         
 
@@ -92,6 +94,7 @@ exclude-result-prefixes="xsl md panxslt set">
       <xsl:if test="$dataset_version_major">
         <version>
           <xsl:value-of select="$dataset_version_major" />
+          <!-- TODO: Check if dataset_version_minor's value should be selected here instead -->
           <xsl:if test="$dataset_version_minor"><xsl:text>.</xsl:text><xsl:value-of select="$dataset_version_major" />
             <xsl:if test="$dataset_version_modifier"><xsl:text>.</xsl:text><xsl:value-of select="$dataset_version_modifier" />
             </xsl:if>
@@ -110,6 +113,7 @@ exclude-result-prefixes="xsl md panxslt set">
           <xsl:if test="./abcd:URI">
             <url><xsl:value-of select="./abcd:URI"/></url>
           </xsl:if>
+          <!-- TODO: Check if this variable is really necessary -->
           <xsl:if test="./abcd:URL">
             <url><xsl:value-of select="./abcd:URL"/></url>
           </xsl:if>
@@ -343,7 +347,7 @@ exclude-result-prefixes="xsl md panxslt set">
                   <identifier><xsl:value-of select="."/></identifier>
                 </xsl:for-each>
               </xsl:if>
-              
+
               <!-- name -->
               <name><xsl:value-of select="./abcd:Organisation/abcd:Name/abcd:Representation/abcd:Text"/></name>
               <xsl:if test="./abcd:Organisation/abcd:Name/abcd:Representation/abcd:Abbreviation">
@@ -361,7 +365,7 @@ exclude-result-prefixes="xsl md panxslt set">
                   </xsl:for-each>
                 </xsl:otherwise>
               </xsl:choose>
-              
+
               <!-- phone -->
               <xsl:choose>        
                 <xsl:when test="./abcd:TelephoneNumbers/abcd:TelephoneNumber[@preferred='true']">
@@ -406,10 +410,21 @@ exclude-result-prefixes="xsl md panxslt set">
         </maintainer>
       </xsl:for-each>
       <xsl:if test="$dataset_contributors">
-        <!-- TODO, slit string by comma and repeat element -->
-        <contributor type="Person">
-          <name><xsl:value-of select="$dataset_contributors"/></name>
-        </contributor>
+        <xsl:choose>
+          <xsl:when test="contains($dataset_contributors,',')">
+            <xsl:variable name="contributors" select="tokenize($dataset_contributors,',')"/>
+            <xsl:for-each select="$contributors">
+              <contributor type="Person">
+                <name><xsl:value-of select="."/></name>
+              </contributor>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <contributor type="Person">
+              <name><xsl:value-of select="$dataset_contributors"/></name>
+            </contributor>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
      <!-- TODO:
        - Gathering Agents as contributors?


### PR DESCRIPTION
#### Tickets
[#2]

#### Justification
Information about _abcd:DataSets/DataSet/Metadata/RevisionData/Contributors_ must be mapped to the [schema:Person](https://schema.org/Person) type of the [schema:contributor](https://schema.org/contributor) property. This information may include several persons.

#### Code changes
A foreach loop has been added for strings with commas that are split and added to the schema property as a list of persons. Otherwise, only one person object is added. The string information is used as the object's [name](https://schema.org/name).
