### PR TITLE
[#5] Add owner roles mapping

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -297,7 +297,7 @@ exclude-result-prefixes="xsl md panxslt set">
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:for-each select="./abcd:EmailAddresses/abcd:EmailAddress">
-                    <emai1><xsl:value-of select="."/></emai1>
+                    <email><xsl:value-of select="."/></email>
                   </xsl:for-each>
                 </xsl:otherwise>
               </xsl:choose>
@@ -324,6 +324,11 @@ exclude-result-prefixes="xsl md panxslt set">
                   </xsl:if>
                 </affiliation>
               </xsl:if>
+
+              <!-- jobTitle: Roles -->
+              <xsl:for-each select="./abcd:Roles/abcd:Role">
+                <jobTitle><xsl:value-of select="."/></jobTitle>
+              </xsl:for-each>
             </author>
           </xsl:when>
           <xsl:otherwise>
@@ -357,7 +362,7 @@ exclude-result-prefixes="xsl md panxslt set">
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:for-each select="./abcd:EmailAddresses/abcd:EmailAddress">
-                    <emai1><xsl:value-of select="."/></emai1>
+                    <email><xsl:value-of select="."/></email>
                   </xsl:for-each>
                 </xsl:otherwise>
               </xsl:choose>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -30,6 +30,49 @@
                 <DateCreated>1999-10-19T00:00:00</DateCreated>
                 <DateModified>2018-01-22T00:00:00</DateModified>
             </RevisionData>
+            <Owners>
+                <Owner>
+                    <Organisation>
+                        <Name>
+                        <Representation language="en">
+                            <Text>Botanic Garden and Botanical Museum Berlin</Text>
+                            <Abbreviation>BGBM</Abbreviation>
+                        </Representation>
+                        </Name>
+                    </Organisation>
+                    <Addresses>
+                        <Address>Königin-Luise-Str. 6-8, 14195 Berlin, Germany</Address>
+                    </Addresses>
+                    <EmailAddresses>
+                        <EmailAddress>biodiversitydata@bgbm.org</EmailAddress>
+                    </EmailAddresses>
+                    <URIs>
+                        <URL>http://www.bgbm.org</URL>
+                    </URIs>
+                </Owner>
+                <Owner>
+                    <Organisation>
+                        <Name>
+                        <Representation language="en">
+                            <Text>Botanic Garden and Botanical Museum Berlin</Text>
+                            <Abbreviation>BGBM</Abbreviation>
+                        </Representation>
+                        </Name>
+                    </Organisation>
+                    <Person>
+                        <FullName>Anke Hoffmann</FullName>
+                    </Person>
+                    <Addresses>
+                        <Address>Königin-Luise-Str. 6-8, 14195 Berlin, Germany</Address>
+                    </Addresses>
+                    <EmailAddresses>
+                        <EmailAddress>biodiversitydata@bgbm.org</EmailAddress>
+                    </EmailAddresses>
+                    <URIs>
+                        <URL>http://www.bgbm.org</URL>
+                    </URIs>
+                </Owner>
+            </Owners>
             <IPRStatements>
                 <Licenses>
                     <License language="en">

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -62,6 +62,10 @@
                     <Person>
                         <FullName>Anke Hoffmann</FullName>
                     </Person>
+                    <Roles>
+                        <Role>Database administrator</Role>
+                        <Role>Project manager</Role>
+                    </Roles>
                     <Addresses>
                         <Address>Königin-Luise-Str. 6-8, 14195 Berlin, Germany</Address>
                     </Addresses>


### PR DESCRIPTION
#### Tickets
[#5]

#### Justification
Information about _abcd:DataSets/DataSet/Metadata/Owners/Owner/Roles_ must be mapped to the [schema:jobTitle](https://schema.org/contributor) property of [schema:Person](https://schema.org/Person). Several roles may be included.

#### Code changes
A foreach loop extracts roles and maps this information to jobTitle.

Two owners has been added to the example XML: One organization entity and one person entity. The latter has been modified to include two roles.

Removed typos (emai1 &rarr; email).

