### PR TITLE
[#6] Added citation mapping

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -24,7 +24,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="dataset_version_modifier" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:Modifier"></xsl:variable>
   <xsl:variable name="dataset_version_issued" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:DateIssued"></xsl:variable>
   <xsl:variable name="dataset_direct_access" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:DirectAccessURI"></xsl:variable>
-  <xsl:variable name="ipr_statement" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Citations/abcd:Citation/abcd:Text"></xsl:variable>
+  <xsl:variable name="ipr_statement" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Citations/abcd:Citation"></xsl:variable>
   <xsl:variable name="dataset_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Description/abcd:Representation/abcd:URI"></xsl:variable>
   <xsl:variable name="terms_of_use" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:TermsOfUseStatements/abcd:TermsOfUse"></xsl:variable>
   <xsl:variable name="licence" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Licenses/abcd:License"></xsl:variable>
@@ -104,7 +104,7 @@ exclude-result-prefixes="xsl md panxslt set">
           <xsl:if test="./abcd:Text">
             <name><xsl:value-of select="./abcd:Text"/></name>
           </xsl:if>
-          <xsl:if test="./abcd:Text">
+          <xsl:if test="./abcd:Details">
             <description><xsl:value-of select="./abcd:Details"/></description>
           </xsl:if>
           <xsl:if test="./abcd:URI">
@@ -122,7 +122,7 @@ exclude-result-prefixes="xsl md panxslt set">
           <xsl:if test="./abcd:Text">
             <name><xsl:value-of select="./abcd:Text"/></name>
           </xsl:if>
-          <xsl:if test="./abcd:Text">
+          <xsl:if test="./abcd:Details">
             <description><xsl:value-of select="./abcd:Details"/></description>
           </xsl:if>
           <xsl:if test="./abcd:URI">
@@ -133,6 +133,25 @@ exclude-result-prefixes="xsl md panxslt set">
           </xsl:if>
         </usageInfo>
       </xsl:for-each>
+
+      <xsl:for-each select="$ipr_statement">
+        <usageInfo>
+          <xsl:attribute name="type">CreativeWork</xsl:attribute>
+          <xsl:if test="./abcd:Text">
+            <name><xsl:value-of select="./abcd:Text"/></name>
+          </xsl:if>
+          <xsl:if test="./abcd:Details">
+            <description><xsl:value-of select="./abcd:Details"/></description>
+          </xsl:if>
+          <xsl:if test="./abcd:URI">
+            <url><xsl:value-of select="./abcd:URI"/></url>
+          </xsl:if>
+          <xsl:if test="./abcd:URL">
+            <url><xsl:value-of select="./abcd:URL"/></url>
+          </xsl:if>
+        </usageInfo>
+      </xsl:for-each>
+
       
     <xsl:for-each select="$country[not(.=preceding::*)]">  
       <spatialCoverage type="Country">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -24,7 +24,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="dataset_version_modifier" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:Modifier"></xsl:variable>
   <xsl:variable name="dataset_version_issued" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:DateIssued"></xsl:variable>
   <xsl:variable name="dataset_direct_access" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:DirectAccessURI"></xsl:variable>
-  <xsl:variable name="ipr_statement" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Citations/abcd:Citation"></xsl:variable>
+  <xsl:variable name="dataset_citation" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Citations/abcd:Citation"></xsl:variable>
   <xsl:variable name="dataset_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Description/abcd:Representation/abcd:URI"></xsl:variable>
   <xsl:variable name="terms_of_use" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:TermsOfUseStatements/abcd:TermsOfUse"></xsl:variable>
   <xsl:variable name="licence" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:IPRStatements/abcd:Licenses/abcd:License"></xsl:variable>
@@ -102,7 +102,7 @@ exclude-result-prefixes="xsl md panxslt set">
         <license>
           <xsl:attribute name="type">CreativeWork</xsl:attribute>
           <xsl:if test="./abcd:Text">
-            <name><xsl:value-of select="./abcd:Text"/></name>
+            <text><xsl:value-of select="./abcd:Text"/></text>
           </xsl:if>
           <xsl:if test="./abcd:Details">
             <description><xsl:value-of select="./abcd:Details"/></description>
@@ -119,8 +119,9 @@ exclude-result-prefixes="xsl md panxslt set">
       <xsl:for-each select="$terms_of_use">
         <usageInfo>
           <xsl:attribute name="type">CreativeWork</xsl:attribute>
+          <name>Terms of Use</name>
           <xsl:if test="./abcd:Text">
-            <name><xsl:value-of select="./abcd:Text"/></name>
+            <text><xsl:value-of select="./abcd:Text"/></text>
           </xsl:if>
           <xsl:if test="./abcd:Details">
             <description><xsl:value-of select="./abcd:Details"/></description>
@@ -134,11 +135,12 @@ exclude-result-prefixes="xsl md panxslt set">
         </usageInfo>
       </xsl:for-each>
 
-      <xsl:for-each select="$ipr_statement">
+      <xsl:for-each select="$dataset_citation">
         <usageInfo>
           <xsl:attribute name="type">CreativeWork</xsl:attribute>
+          <name>Suggested Citation</name>
           <xsl:if test="./abcd:Text">
-            <name><xsl:value-of select="./abcd:Text"/></name>
+            <text><xsl:value-of select="./abcd:Text"/></text>
           </xsl:if>
           <xsl:if test="./abcd:Details">
             <description><xsl:value-of select="./abcd:Details"/></description>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -36,6 +36,11 @@
                         <Text>CC BY 4.0</Text>
                     </License>
                 </Licenses>
+                <TermsOfUseStatements>
+                    <TermsOfUse language="en">
+                        <Text>Textual metadata on specimens from the Herbarium Berolinense (B) are released under the Creative Commons 1.0 Public Domain Dedication waiver [http://creativecommons.org/publicdomain/zero/1.0/].</Text>
+                    </TermsOfUse>
+                </TermsOfUseStatements>
                 <Citations>
                     <Citation language="en">
                         <Text>Hoffmann, A. (1999). Plants at Crater Road of Queen Elizabeth National Park, Uganda. [Dataset]. Data Publisher: Botanic Garden and Botanical Museum Berlin.  https://data.bgbm.org/dataset/gfbio/0004/.</Text>


### PR DESCRIPTION
#### Tickets
[#6]

#### Justification
Information about _abcd:/DataSets/DataSet/Metadata/IPRStatements/Citations/Citation_ must be mapped to the [schema:usageInfo](https://schema.org/usageInfo) property of [schema:Dataset](https://schema.org/Dataset). This is a [schema:CreativeWork](https://schema.org/CreativeWork) with the properties name (mapped from abcd:Text), description (from abcd:Details and url (from abcd:URI).

#### Code changes
XSLT file:
- Changed level of IPRStatements variable.
- Added ipr_statements mapping to a CreativeWork type.
- Fixed Details/Text bug.
XML file:
Extended example by TermsOfUseStatements which is already be mapped.
