### PR TITLE
[#12] Extend mapping to spatial coverage

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -146,7 +146,9 @@ exclude-result-prefixes="xsl md panxslt set">
       <xsl:for-each select="$unit_country[not(.=preceding::*)]">  
         <spatialCoverage type="Country">
           <name><xsl:value-of select="."/></name>
-          <identifier><xsl:value-of select="../abcd:ISO3166Code"/></identifier>
+          <xsl:if test="../abcd:ISO3166Code"/>
+            <identifier><xsl:value-of select="../abcd:ISO3166Code"/></identifier>
+          </xsl:if>
         </spatialCoverage>
       </xsl:for-each>
 

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -173,16 +173,6 @@ exclude-result-prefixes="xsl md panxslt set">
                   </xsl:if>
                 </geo>
               </xsl:if>
-              <xsl:if test="$unit_named_areas">
-                <xsl:for-each select="$unit_named_areas">
-                  <containedInPlace type="Place">
-                    <name><xsl:value-of select="."/></name>
-                    <xsl:if test="./abcd:AreaClass">
-                      <additionalType><xsl:value-of select="./abcd:AreaClass"/></additionalType>
-                    </xsl:if>
-                  </containedInPlace>
-                </xsl:for-each>
-              </xsl:if>
             </spatialCoverage>
           </xsl:when>
           <xsl:otherwise>

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -140,7 +140,6 @@ exclude-result-prefixes="xsl md panxslt set">
       <xsl:variable name="unit_latitude" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:LatitudeDecimal"></xsl:variable>
       <xsl:variable name="unit_longitude" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:LongitudeDecimal"></xsl:variable>
       <xsl:variable name="unit_spatial_datum" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:SpatialDatum"></xsl:variable>
-      <xsl:variable name="unit_altitude" select="./abcd:Gathering/abcd:Altitude"></xsl:variable>
       <xsl:variable name="unit_country" select="./abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
       <xsl:variable name="unit_named_areas" select="./abcd:Gathering/abcd:NamedAreas/abcd:NamedArea"></xsl:variable>
 
@@ -151,37 +150,72 @@ exclude-result-prefixes="xsl md panxslt set">
         </spatialCoverage>
       </xsl:for-each>
 
-      <xsl:for-each select="$unit_locality[not(.=preceding::*)]">  
-        <spatialCoverage type="Place">
-          <name><xsl:value-of select="."/></name>
-          <description><xsl:value-of select="."/></description>
-          <xsl:if test="$unit_coordinates">
-            <geo type="GeoCoordinates">
-              <xsl:if test="$unit_latitude">
-                <latitude xsi:type="xs:double"><xsl:value-of select="$unit_latitude"/></latitude>
+      <xsl:for-each select="$unit_locality">
+        <xsl:choose>
+          <xsl:variable name="preceding_latitude" select="preceding::*[self::abcd:CoordinatesLatLong][1]/abcd:LatitudeDecimal"></xsl:variable>
+          <xsl:variable name="preceding_longitude" select="preceding::*[self::abcd:CoordinatesLatLong][1]/abcd:LongitudeDecimal"></xsl:variable>
+          <xsl:when test="not(.=preceding::*)">
+            <spatialCoverage type="Place">
+              <name><xsl:value-of select="."/></name>
+              <description><xsl:value-of select="."/></description>
+              <xsl:if test="$unit_coordinates">
+                <geo type="GeoCoordinates">
+                  <xsl:if test="$unit_latitude">
+                    <latitude xsi:type="xs:double"><xsl:value-of select="$unit_latitude"/></latitude>
+                  </xsl:if>
+                  <xsl:if test="$unit_longitude">
+                    <longitude xsi:type="xs:double"><xsl:value-of select="$unit_longitude"/></longitude>
+                  </xsl:if>
+                  <xsl:if test="$unit_spatial_datum">
+                    <additionalType><xsl:value-of select="$unit_spatial_datum"/></additionalType>
+                  </xsl:if>
+                </geo>
               </xsl:if>
-              <xsl:if test="$unit_longitude">
-                <longitude xsi:type="xs:double"><xsl:value-of select="$unit_longitude"/></longitude>
+              <xsl:if test="$unit_named_areas">
+                <xsl:for-each select="$unit_named_areas">
+                  <containedInPlace type="Place">
+                    <name><xsl:value-of select="."/></name>
+                    <xsl:if test="./abcd:AreaClass">
+                      <additionalType><xsl:value-of select="./abcd:AreaClass"/></additionalType>
+                    </xsl:if>
+                  </containedInPlace>
+                </xsl:for-each>
               </xsl:if>
-              <xsl:if test="$unit_spatial_datum">
-                <additionalType><xsl:value-of select="$unit_spatial_datum"/></additionalType>
-              </xsl:if>
-              <xsl:if test="$unit_altitude">
-                <elevation xsi:type="xs:double"><xsl:value-of select="$unit_altitude"/></elevation>
-              </xsl:if>
-            </geo>
-          </xsl:if>
-          <xsl:if test="$unit_named_areas">
-            <xsl:for-each select="$unit_named_areas">
-              <containedInPlace type="Place">
+            </spatialCoverage>
+          </xsl:when>
+          <xsl:otherwise>
+            <!-- TODO: Part below can be removed if its if-clause can be combined with the first one -->
+            <xsl:if test="not($preceding_latitude = $unit_latitude and $preceding_longitude = $unit_longitude)">
+              <spatialCoverage type="Place">
                 <name><xsl:value-of select="."/></name>
-                <xsl:if test="./abcd:AreaClass">
-                  <additionalType><xsl:value-of select="./abcd:AreaClass"/></additionalType>
+                <description><xsl:value-of select="."/></description>
+                <xsl:if test="$unit_coordinates">
+                  <geo type="GeoCoordinates">
+                    <xsl:if test="$unit_latitude">
+                      <latitude xsi:type="xs:double"><xsl:value-of select="$unit_latitude"/></latitude>
+                    </xsl:if>
+                    <xsl:if test="$unit_longitude">
+                      <longitude xsi:type="xs:double"><xsl:value-of select="$unit_longitude"/></longitude>
+                    </xsl:if>
+                    <xsl:if test="$unit_spatial_datum">
+                      <additionalType><xsl:value-of select="$unit_spatial_datum"/></additionalType>
+                    </xsl:if>
+                  </geo>
                 </xsl:if>
-              </containedInPlace>
-            </xsl:for-each>
-          </xsl:if>
-        </spatialCoverage>
+                <xsl:if test="$unit_named_areas">
+                  <xsl:for-each select="$unit_named_areas">
+                    <containedInPlace type="Place">
+                      <name><xsl:value-of select="."/></name>
+                      <xsl:if test="./abcd:AreaClass">
+                        <additionalType><xsl:value-of select="./abcd:AreaClass"/></additionalType>
+                      </xsl:if>
+                    </containedInPlace>
+                  </xsl:for-each>
+                </xsl:if>
+              </spatialCoverage>
+            </xsl:if>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
     </xsl:for-each>
 

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -139,6 +139,7 @@ exclude-result-prefixes="xsl md panxslt set">
       <xsl:variable name="unit_coordinates" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
       <xsl:variable name="unit_latitude" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:LatitudeDecimal"></xsl:variable>
       <xsl:variable name="unit_longitude" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:LongitudeDecimal"></xsl:variable>
+      <xsl:variable name="unit_spatial_datum" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:SpatialDatum"></xsl:variable>
       <xsl:variable name="unit_altitude" select="./abcd:Gathering/abcd:Altitude"></xsl:variable>
       <xsl:variable name="unit_country" select="./abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
       <xsl:variable name="unit_named_areas" select="./abcd:Gathering/abcd:NamedAreas/abcd:NamedArea"></xsl:variable>
@@ -161,6 +162,9 @@ exclude-result-prefixes="xsl md panxslt set">
               </xsl:if>
               <xsl:if test="$unit_longitude">
                 <longitude xsi:type="xs:double"><xsl:value-of select="$unit_longitude"/></longitude>
+              </xsl:if>
+              <xsl:if test="$unit_spatial_datum">
+                <additionalType><xsl:value-of select="$unit_spatial_datum"/></additionalType>
               </xsl:if>
               <xsl:if test="$unit_altitude">
                 <elevation xsi:type="xs:double"><xsl:value-of select="$unit_altitude"/></elevation>

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -134,13 +134,53 @@ exclude-result-prefixes="xsl md panxslt set">
         </usageInfo>
       </xsl:for-each>
       
-    <xsl:for-each select="$country[not(.=preceding::*)]">  
-      <spatialCoverage type="Country">
-        <name><xsl:value-of select="."/></name>
-        <identifier><xsl:value-of select="../abcd:ISO3166Code"/></identifier>
-      </spatialCoverage>
+    <xsl:for-each select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit">
+      <xsl:variable name="unit_locality" select="./abcd:Gathering/abcd:LocalityText"></xsl:variable>
+      <xsl:variable name="unit_coordinates" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
+      <xsl:variable name="unit_latitude" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:LatitudeDecimal"></xsl:variable>
+      <xsl:variable name="unit_longitude" select="./abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong/abcd:LongitudeDecimal"></xsl:variable>
+      <xsl:variable name="unit_altitude" select="./abcd:Gathering/abcd:Altitude"></xsl:variable>
+      <xsl:variable name="unit_country" select="./abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
+      <xsl:variable name="unit_named_areas" select="./abcd:Gathering/abcd:NamedAreas/abcd:NamedArea"></xsl:variable>
+
+      <xsl:for-each select="$unit_country[not(.=preceding::*)]">  
+        <spatialCoverage type="Country">
+          <name><xsl:value-of select="."/></name>
+          <identifier><xsl:value-of select="../abcd:ISO3166Code"/></identifier>
+        </spatialCoverage>
+      </xsl:for-each>
+
+      <xsl:for-each select="$unit_locality[not(.=preceding::*)]">  
+        <spatialCoverage type="Place">
+          <name><xsl:value-of select="."/></name>
+          <description><xsl:value-of select="."/></description>
+          <xsl:if test="$unit_coordinates">
+            <geo type="GeoCoordinates">
+              <xsl:if test="$unit_latitude">
+                <latitude xsi:type="xs:double"><xsl:value-of select="$unit_latitude"/></latitude>
+              </xsl:if>
+              <xsl:if test="$unit_longitude">
+                <longitude xsi:type="xs:double"><xsl:value-of select="$unit_longitude"/></longitude>
+              </xsl:if>
+              <xsl:if test="$unit_altitude">
+                <elevation xsi:type="xs:double"><xsl:value-of select="$unit_altitude"/></elevation>
+              </xsl:if>
+            </geo>
+          </xsl:if>
+          <xsl:if test="$unit_named_areas">
+            <xsl:for-each select="$unit_named_areas">
+              <containedInPlace type="Place">
+                <name><xsl:value-of select="."/></name>
+                <xsl:if test="./abcd:AreaClass">
+                  <additionalType><xsl:value-of select="./abcd:AreaClass"/></additionalType>
+                </xsl:if>
+              </containedInPlace>
+            </xsl:for-each>
+          </xsl:if>
+        </spatialCoverage>
+      </xsl:for-each>
     </xsl:for-each>
-      
+
     <!-- get bounding box coordinates or coordinate pair, if there is only one -->
     <xsl:if test="$coordinates/abcd:LatitudeDecimal and $coordinates/abcd:LongitudeDecimal">
       <spatialCoverage type="Place">


### PR DESCRIPTION
#### Tickets
[#12]

#### Justification
In order to filter datasets for geographical information such as free text locality descriptions and names as well as named areas containing these locations, it is necessary to map these information properly:

- _Place_
  - _name_ (from _/abcd:LocalityText_)
  - _geo_
    - _GeoCoordinates_
      - _latitude_ 
      - _longitude_
      - _additionalType_ (from _/abcd:SpatialDatum_)
  - _containedInPlace_
    - _Place_
      - _name_ (from _/abcd:NamedArea_)
      - _additionalType_ (from _/abcd:AreaClass_)

#### Code changes
XSLT file:
- Add variables for extracted XML information
- Add construction of _Place_, which represents a locality and contains name, coordinates, spatial datum and relationship information of a superior named area