### PR TITLE
[#16] Added kind of unit mapping. Updated example.

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -34,6 +34,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="scope_geoecological" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:GeoecologicalTerms/*[self::abcd:GeoecologicalTerm or self::abcd:GeoEcologicalTerm]"></xsl:variable>
   
   <xsl:variable name="recordbasis" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordBasis"></xsl:variable>
+  <xsl:variable name="kind_of_unit" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:KindOfUnit"></xsl:variable>
   <xsl:variable name="coordinates" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
   <xsl:variable name="country" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
   <xsl:variable name="gathering_date" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:DateTime"></xsl:variable>
@@ -65,6 +66,9 @@ exclude-result-prefixes="xsl md panxslt set">
       </description>
       <inLanguage>en</inLanguage>
       <xsl:for-each select="$recordbasis[not(.=preceding::*)]">  
+        <additionalType><xsl:value-of select="."/></additionalType>
+      </xsl:for-each>
+      <xsl:for-each select="$kind_of_unit[not(.=preceding::*)]">  
         <additionalType><xsl:value-of select="."/></additionalType>
       </xsl:for-each>
       <xsl:if test="$dataset_created">

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -208,6 +208,7 @@
                     </Identification>
                 </Identifications>
                 <RecordBasis>HumanObservation</RecordBasis>
+                <KindOfUnit>herbarium sheet</KindOfUnit>
                 <Gathering>
                     <DateTime>
                         <ISODateTimeEnd>1995-06-13</ISODateTimeEnd>
@@ -604,6 +605,7 @@
                     </Identification>
                 </Identifications>
                 <RecordBasis>HumanObservation</RecordBasis>
+                <KindOfUnit>leaves</KindOfUnit>
                 <Gathering>
                     <DateTime>
                         <ISODateTimeEnd>1995-06-13</ISODateTimeEnd>


### PR DESCRIPTION
#### Tickets
[#16]

#### Justification
Searching datasets by information specified in abcd:KindOfUnit can be enabled by adding its free text information to the [schema:additionalType](https://schema.org/additionalType) of the dataset. This can then be used to answer questions such as "What datasets are available with _herbarium sheets_ from Uganda?"

#### Code changes
XSLT file
- Add variable.
- Extract all kind of unit values and add them to additionalType only once.
XML file
- Add respective elements and values.