### PR TITLE
[#19] Add unit level to keywords mapping.

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -217,25 +217,25 @@ exclude-result-prefixes="xsl md panxslt set">
       
       <!-- Keywords -->
       <xsl:for-each select="$scope_taxonomic[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="."/></keywords>
       </xsl:for-each>
       <xsl:for-each select="$scope_geoecological[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="."/></keywords>
       </xsl:for-each>
       <xsl:for-each select="$chronostratigraphic[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="."/></keywords>
       </xsl:for-each>
       <xsl:for-each select="$biostratigraphic[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="."/></keywords>
       </xsl:for-each>
       <xsl:for-each select="$lithostratigraphic[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="."/></keywords>
       </xsl:for-each>
       <xsl:for-each select="$biotope[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="./abcd:Name"/></keywords>
       </xsl:for-each>
       <xsl:for-each select="$project_title[not(.=preceding::*)]">  
-        <keyword><xsl:value-of select="."/></keyword>
+        <keywords><xsl:value-of select="."/></keywords>
       </xsl:for-each>
       
       <xsl:for-each select="$taxon_name[not(.=preceding::*)]">  

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -42,9 +42,9 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
+  <xsl:variable name="biotope" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Biotope"></xsl:variable>
+  <xsl:variable name="project_title" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Project/abcd:ProjectTitle"></xsl:variable>
   
-
-        
 
   <xsl:template match="/*">
     <jsonld>
@@ -229,6 +229,12 @@ exclude-result-prefixes="xsl md panxslt set">
         <keyword><xsl:value-of select="."/></keyword>
       </xsl:for-each>
       <xsl:for-each select="$lithostratigraphic[not(.=preceding::*)]">  
+        <keyword><xsl:value-of select="."/></keyword>
+      </xsl:for-each>
+      <xsl:for-each select="$biotope[not(.=preceding::*)]">  
+        <keyword><xsl:value-of select="."/></keyword>
+      </xsl:for-each>
+      <xsl:for-each select="$project_title[not(.=preceding::*)]">  
         <keyword><xsl:value-of select="."/></keyword>
       </xsl:for-each>
       

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -5182,6 +5182,12 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Biotope>
+                        <Name>Woodland</Name>
+                    </Biotope>
+                    <Project>
+                        <ProjectTitle>Amaranthaceae in Uganda</ProjectTitle>
+                    </Project>
                 </Gathering>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/301</RecordURI>
             </Unit>


### PR DESCRIPTION
#### Tickets
[#19]

#### Justification
Searching for _abcd:Gathering/Biotope_ descriptions may be important to answer related dataset search queries. Also, information about titles (_abcd:ProjectTitle_) could be used to filter datasets. Both can be mapped to [schema:keywords](https://schema.org/keywords).

#### Code changes
XSLT file
- Add variables.
- Extract values of both variables and add them accordingly once each.

XML file
- Add examples for both mappings.