### PR TITLE
[#20] Add record uri to unit-level entities in dataset

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -43,7 +43,6 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  <xsl:variable name="record_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordURI"></xsl:variable>
 
         
 

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -135,7 +135,6 @@ exclude-result-prefixes="xsl md panxslt set">
         </usageInfo>
       </xsl:for-each>
 
-    <!-- for each unit check if recordURI is a HTTP URL (contains a http). If so, use it as both identifier and url. If not, use the recordURI as identifier. -->
     <xsl:for-each select="$unit">
       <xsl:if test="./abcd:RecordURI">
         <about type="BioSample">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -33,6 +33,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="scope_taxonomic" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:TaxonomicTerms/abcd:TaxonomicTerm"></xsl:variable>
   <xsl:variable name="scope_geoecological" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:GeoecologicalTerms/*[self::abcd:GeoecologicalTerm or self::abcd:GeoEcologicalTerm]"></xsl:variable>
   
+  <xsl:variable name="unit" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit"></xsl:variable>
   <xsl:variable name="recordbasis" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordBasis"></xsl:variable>
   <xsl:variable name="coordinates" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
   <xsl:variable name="country" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
@@ -42,7 +43,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  
+  <xsl:variable name="record_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordURI"></xsl:variable>
 
         
 
@@ -133,6 +134,19 @@ exclude-result-prefixes="xsl md panxslt set">
           </xsl:if>
         </usageInfo>
       </xsl:for-each>
+
+    <!-- for each unit check if recordURI is a HTTP URL (contains a http). If so, use it as both identifier and url. If not, use the recordURI as identifier. -->
+    <xsl:for-each select="$unit">
+      <xsl:if test="./abcd:RecordURI">
+        <about type="BioSample">
+          <xsl:variable name="record_uri" select="./abcd:RecordURI"></xsl:variable>
+          <identifier><xsl:value-of select="$record_uri"/></identifier>
+          <xsl:if test="contains($record_uri,'http')">
+            <url><xsl:value-of select="$record_uri"/></url>
+          </xsl:if>
+        </about>
+      </xsl:if>
+    </xsl:for-each>
       
     <xsl:for-each select="$country[not(.=preceding::*)]">  
       <spatialCoverage type="Country">

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -233,7 +233,7 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
-                <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/6</RecordURI>
+                <RecordURI>B/HoffmannPlants/6</RecordURI>
             </Unit>
             <Unit>
                 <SourceInstitutionID>B</SourceInstitutionID>


### PR DESCRIPTION
#### Tickets
[#20]

#### Justification
Searching for datasets using record URIs can be a use case. Thus, information in _abcd:./RecordURI_ needs to be mapped to the [schema:identifier](https://schema.org/identifier) property of a freshly created [bioschemas:BioSample](https://bioschemas.org/types/BioSample/0.1-RELEASE-2019_06_19) entity. In case this URI contains 'http', it can also be added to [schema:url](https://schema.org/url) of the same entity. Bio samples are added to the [schema:about](https://schema.org/about) property of the dataset.

#### Code changes
XSLT file
- Add variable each for unit and record URI.
- For each extracted unit, a _BioSample_ is to be created with the information specified above in _Justification_.

XML file
- Change a record URI to a non-HTTP identifier in order to test both URI cases.