### PR TITLE
[#3] Add revision data creators mapping

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -413,9 +413,21 @@ exclude-result-prefixes="xsl md panxslt set">
         </contributor>
       </xsl:if>
       <xsl:if test="$dataset_creators">
-        <creator type="Thing">
-          <name><xsl:value-of select="$dataset_creators"/></name>
-        </creator>
+        <xsl:choose>
+          <xsl:when test="contains($dataset_creators,',')">
+            <xsl:variable name="creators" select="tokenize($dataset_creators,',')"/>
+            <xsl:for-each select="$creators">
+              <creator type="Thing">
+                <name><xsl:value-of select="."/></name>
+              </creator>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <creator type="Thing">
+              <name><xsl:value-of select="$dataset_creators"/></name>
+            </creator>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
      <!-- TODO:
        - Gathering Agents as contributors?

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -18,6 +18,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="dataset_owner" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Owners/abcd:Owner"></xsl:variable>
   <xsl:variable name="dataset_created" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:RevisionData/abcd:DateCreated"></xsl:variable>
   <xsl:variable name="dataset_modified" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:RevisionData/abcd:DateModified"></xsl:variable>
+  <xsl:variable name="dataset_creators" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:RevisionData/abcd:Creators"></xsl:variable>
   <xsl:variable name="dataset_contributors" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:RevisionData/abcd:Contributors"></xsl:variable>
   <xsl:variable name="dataset_version_major" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:Major"></xsl:variable>
   <xsl:variable name="dataset_version_minor" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Version/abcd:Minor"></xsl:variable>
@@ -410,6 +411,11 @@ exclude-result-prefixes="xsl md panxslt set">
         <contributor type="Person">
           <name><xsl:value-of select="$dataset_contributors"/></name>
         </contributor>
+      </xsl:if>
+      <xsl:if test="$dataset_creators">
+        <creator type="Thing">
+          <name><xsl:value-of select="$dataset_creators"/></name>
+        </creator>
       </xsl:if>
      <!-- TODO:
        - Gathering Agents as contributors?


### PR DESCRIPTION
#### Tickets
[#3]

#### Justification
Creators of datasets is information that can be useful for searching for datasets. For this purpose, it has to be mapped to the [schema:creator](https://schema.org/creator) property of a [schema:dataset](https://schema.org/Dataset). Since the value range of _abcd:./RevisionData/Creators_ complies with _dcterms:Creators_, it can describe either persons or organizations and is therefore mapped as [schema:Thing](https://schema.org/Thing).

#### Code changes
XSLT file
- Add variable for creators.
- Check if the string contains commas and split and map it accordingly.