### PR TITLE
[#14] Add multimedia objects mapping

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -222,6 +222,7 @@ exclude-result-prefixes="xsl md panxslt set">
         <mainEntityOfPage><xsl:value-of select="./abcd:ProductURI"/></mainEntityOfPage>
         <encodingFormat><xsl:value-of select="./abcd:Format"/></encodingFormat>
         <contentSize><xsl:value-of select="./abcd:FileSize"/> kB</contentSize>
+        <description><xsl:value-of select="./abcd:Context"/></description>
         <xsl:for-each select="./abcd:IPR/abcd:Licenses/abcd:License">
           <license type="CreativeWork">
             <xsl:if test="./abcd:Text">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -42,7 +42,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  
+  <xsl:variable name="multimedia_object" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:MultimediaObjects/abcd:MultimediaObject"></xsl:variable>
 
         
 
@@ -214,6 +214,20 @@ exclude-result-prefixes="xsl md panxslt set">
           </xsl:if>
         </temporalCoverage>
       </xsl:if>
+
+      <!-- associatedMedia -->
+      <xsl:for-each select="$multimedia_object">
+        <associatedMedia>
+          <contentUrl><xsl:value-of select="./abcd:FileURI"/></contentUrl>
+          <mainEntityOfPage><xsl:value-of select="./abcd:ProductURI"/></mainEntityOfPage>
+          <encodingFormat><xsl:value-of select="./abcd:MIMEType"/></encodingFormat>
+          <xsl:for-each select="./IPR/Licenses/License">
+            <name><xsl:value-of select="./Text"/></name>
+            <description><xsl:value-of select="./Details"/></description>
+            <uri><xsl:value-of select="./URI"/></uri>
+          </xsl:for-each>
+        </associatedMedia>
+      </xsl:for-each>    
       
       <!-- Keywords -->
       <xsl:for-each select="$scope_taxonomic[not(.=preceding::*)]">  

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -221,6 +221,7 @@ exclude-result-prefixes="xsl md panxslt set">
         <contentUrl><xsl:value-of select="./abcd:FileURI"/></contentUrl>
         <mainEntityOfPage><xsl:value-of select="./abcd:ProductURI"/></mainEntityOfPage>
         <encodingFormat><xsl:value-of select="./abcd:Format"/></encodingFormat>
+        <contentSize><xsl:value-of select="./abcd:FileSize"/> kB</contentSize>
         <xsl:for-each select="./abcd:IPR/abcd:Licenses/abcd:License">
           <license type="CreativeWork">
             <xsl:if test="./abcd:Text">
@@ -236,7 +237,7 @@ exclude-result-prefixes="xsl md panxslt set">
         </xsl:for-each>
         <xsl:if test="./abcd:Creator">
           <creator type="Person">
-            <name><xsl:value-of select="./abcd:Creator"/></name>#
+            <name><xsl:value-of select="./abcd:Creator"/></name>
           </creator>
         </xsl:if>
       </associatedMedia>

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -223,6 +223,10 @@ exclude-result-prefixes="xsl md panxslt set">
         <encodingFormat><xsl:value-of select="./abcd:Format"/></encodingFormat>
         <contentSize><xsl:value-of select="./abcd:FileSize"/> kB</contentSize>
         <description><xsl:value-of select="./abcd:Context"/></description>
+        <dateCreated type="xs:date"><xsl:value-of select="./abcd:CreatedDate"/></dateCreated>    
+        <creator type="Person">
+          <name><xsl:value-of select="./abcd:Creator"/></name>
+        </creator>
         <xsl:for-each select="./abcd:IPR/abcd:Licenses/abcd:License">
           <license type="CreativeWork">
             <xsl:if test="./abcd:Text">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -42,7 +42,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  <xsl:variable name="multimedia_object" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:MultimediaObjects/abcd:MultimediaObject"></xsl:variable>
+  <xsl:variable name="multimedia_object" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:MultiMediaObjects/abcd:MultiMediaObject"></xsl:variable>
 
         
 
@@ -215,19 +215,32 @@ exclude-result-prefixes="xsl md panxslt set">
         </temporalCoverage>
       </xsl:if>
 
-      <!-- associatedMedia -->
-      <xsl:for-each select="$multimedia_object">
-        <associatedMedia>
-          <contentUrl><xsl:value-of select="./abcd:FileURI"/></contentUrl>
-          <mainEntityOfPage><xsl:value-of select="./abcd:ProductURI"/></mainEntityOfPage>
-          <encodingFormat><xsl:value-of select="./abcd:MIMEType"/></encodingFormat>
-          <xsl:for-each select="./IPR/Licenses/License">
-            <name><xsl:value-of select="./Text"/></name>
-            <description><xsl:value-of select="./Details"/></description>
-            <uri><xsl:value-of select="./URI"/></uri>
-          </xsl:for-each>
-        </associatedMedia>
-      </xsl:for-each>    
+    <!-- associatedMedia -->
+    <xsl:for-each select="$multimedia_object">
+      <associatedMedia type="MediaObject">
+        <contentUrl><xsl:value-of select="./abcd:FileURI"/></contentUrl>
+        <mainEntityOfPage><xsl:value-of select="./abcd:ProductURI"/></mainEntityOfPage>
+        <encodingFormat><xsl:value-of select="./abcd:Format"/></encodingFormat>
+        <xsl:for-each select="./abcd:IPR/abcd:Licenses/abcd:License">
+          <license type="CreativeWork">
+            <xsl:if test="./abcd:Text">
+              <name><xsl:value-of select="./abcd:Text"/></name>
+            </xsl:if>
+            <xsl:if test="./abcd:Details">
+              <description><xsl:value-of select="./abcd:Details"/></description>
+            </xsl:if>
+            <xsl:if test="./abcd:URI">
+              <url><xsl:value-of select="./abcd:URI"/></url>
+            </xsl:if>
+          </license>
+        </xsl:for-each>
+        <xsl:if test="./abcd:Creator">
+          <creator type="Person">
+            <name><xsl:value-of select="./abcd:Creator"/></name>#
+          </creator>
+        </xsl:if>
+      </associatedMedia>
+    </xsl:for-each>    
       
       <!-- Keywords -->
       <xsl:for-each select="$scope_taxonomic[not(.=preceding::*)]">  

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -84,6 +84,36 @@
                     </Identification>
                 </Identifications>
                 <RecordBasis>HumanObservation</RecordBasis>
+                <MultiMediaObjects>
+                    <MultiMediaObject>
+                        <FileURI>https://image.bgbm.org/images/internal/HerbarThumbs/test0</FileURI>
+                        <ProductURI>https://herbarium.bgbm.org/object/test0</ProductURI>
+                        <Format>image/jpeg</Format>
+                        <IPR>
+                            <Licenses>
+                                <License>
+                                    <Text>Partial images provided by this server are released under the Creative Commons cc-by-sa 3.0 (generic) licence [https://creativecommons.org/licenses/by-sa/3.0/de/]. Please credit images to BGBM following our citation guidelines [https://ww2.bgbm.org/Herbarium/cite.cfm]. If you would like to use images in a format or resolution which is not provided here, please contact us (d.roepert[at]bgbm.org).</Text>
+                                    <URI>https://creativecommons.org/licenses/by-sa/3.0/</URI>
+                                </License>
+                            </Licenses>
+                        </IPR>
+                        <Creator>Hoffmann, Anke</Creator>
+                    </MultiMediaObject>
+                    <MultiMediaObject>
+                        <FileURI>https://herbarium.bgbm.org/data/iiif/test0/manifest.json</FileURI>
+                        <ProductURI>https://iiif.bgbm.org/?manifest=https://herbarium.bgbm.org/object/test0/manifest.json</ProductURI>
+                        <Format>application/json</Format>
+                        <IPR>
+                            <Licenses>
+                                <License>
+                                    <Text>Partial images provided by this server are released under the Creative Commons cc-by-sa 3.0 (generic) licence [https://creativecommons.org/licenses/by-sa/3.0/de/]. Please credit images to BGBM following our citation guidelines [https://ww2.bgbm.org/Herbarium/cite.cfm]. If you would like to use images in a format or resolution which is not provided here, please contact us (d.roepert[at]bgbm.org).</Text>
+                                    <URI>https://creativecommons.org/licenses/by-sa/3.0/</URI>
+                                </License>
+                            </Licenses>
+                        </IPR>
+                        <Creator>Hoffmann, Anke</Creator>
+                    </MultiMediaObject>
+                </MultiMediaObjects>
                 <Gathering>
                     <DateTime>
                         <ISODateTimeEnd>1995-06-13</ISODateTimeEnd>
@@ -150,6 +180,34 @@
                     </Identification>
                 </Identifications>
                 <RecordBasis>HumanObservation</RecordBasis>
+                <MultiMediaObjects>
+                    <MultiMediaObject>
+                        <FileURI>https://image.bgbm.org/images/internal/HerbarThumbs/test1</FileURI>
+                        <ProductURI>https://herbarium.bgbm.org/object/test1</ProductURI>
+                        <Format>image/jpeg</Format>
+                        <IPR>
+                            <Licenses>
+                                <License language="en">
+                                    <Text>Partial images provided by this server are released under the Creative Commons cc-by-sa 3.0 (generic) licence [https://creativecommons.org/licenses/by-sa/3.0/de/]. Please credit images to BGBM following our citation guidelines [https://ww2.bgbm.org/Herbarium/cite.cfm]. If you would like to use images in a format or resolution which is not provided here, please contact us (d.roepert[at]bgbm.org).</Text>
+                                    <URI>https://creativecommons.org/licenses/by-sa/3.0/</URI>
+                                </License>
+                            </Licenses>
+                        </IPR>
+                    </MultiMediaObject>
+                    <MultiMediaObject>
+                        <FileURI>https://herbarium.bgbm.org/data/iiif/test1/manifest.json</FileURI>
+                        <ProductURI>https://iiif.bgbm.org/?manifest=https://herbarium.bgbm.org/object/test1/manifest.json</ProductURI>
+                        <Format>application/json</Format>
+                        <IPR>
+                            <Licenses>
+                                <License language="en">
+                                    <Text>Partial images provided by this server are released under the Creative Commons cc-by-sa 3.0 (generic) licence [https://creativecommons.org/licenses/by-sa/3.0/de/]. Please credit images to BGBM following our citation guidelines [https://ww2.bgbm.org/Herbarium/cite.cfm]. If you would like to use images in a format or resolution which is not provided here, please contact us (d.roepert[at]bgbm.org).</Text>
+                                    <URI>https://creativecommons.org/licenses/by-sa/3.0/</URI>
+                                </License>
+                            </Licenses>
+                        </IPR>
+                    </MultiMediaObject>
+                </MultiMediaObjects>
                 <Gathering>
                     <DateTime>
                         <ISODateTimeEnd>1995-06-13</ISODateTimeEnd>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -89,6 +89,7 @@
                         <FileURI>https://image.bgbm.org/images/internal/HerbarThumbs/test0</FileURI>
                         <ProductURI>https://herbarium.bgbm.org/object/test0</ProductURI>
                         <Format>image/jpeg</Format>
+                        <FileSize>123456</FileSize>
                         <IPR>
                             <Licenses>
                                 <License>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -91,6 +91,8 @@
                         <Format>image/jpeg</Format>
                         <FileSize>123456</FileSize>
                         <Context>Image of a plant specimen collected in Uganda.</Context>
+                        <CreatedDate>2001-10-26</CreatedDate>
+                        <Creator>Hoffmann (203001113)</Creator>
                         <IPR>
                             <Licenses>
                                 <License>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -90,6 +90,7 @@
                         <ProductURI>https://herbarium.bgbm.org/object/test0</ProductURI>
                         <Format>image/jpeg</Format>
                         <FileSize>123456</FileSize>
+                        <Context>Image of a plant specimen collected in Uganda.</Context>
                         <IPR>
                             <Licenses>
                                 <License>


### PR DESCRIPTION
#### Tickets
[#14]

#### Justification
If existing, _abcd:./Unit/MultiMediaObjects_ are an important component of dataset records. For this reason, it is likely that it is used as search information, for example to return all datasets containing images or to extend the free text search to media objects. To enable this search feature, the indiviual multimedia object elements are mapped to the [schema:CreativeWork](https://schema.org/CreativeWork) of the [schema:associatedMedia](https://schema.org/associatedMedia) property, as described in the linked ticket.

#### Code changes
XSLT file
- Added variable for multimedia objects.
- Mapping for ABCD multimedia elements.

XML file
- Added examples.