### PR TITLE
[#21] Add citation mapping.

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -34,6 +34,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="scope_geoecological" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:GeoecologicalTerms/*[self::abcd:GeoecologicalTerm or self::abcd:GeoEcologicalTerm]"></xsl:variable>
   
   <xsl:variable name="recordbasis" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordBasis"></xsl:variable>
+  <xsl:variable name="source_reference" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:SourceReference"></xsl:variable>
   <xsl:variable name="coordinates" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
   <xsl:variable name="country" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
   <xsl:variable name="gathering_date" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:DateTime"></xsl:variable>
@@ -230,6 +231,21 @@ exclude-result-prefixes="xsl md panxslt set">
       </xsl:for-each>
       <xsl:for-each select="$lithostratigraphic[not(.=preceding::*)]">  
         <keyword><xsl:value-of select="."/></keyword>
+      </xsl:for-each>
+
+      <!-- citation -->
+      <xsl:for-each select="$source_reference[not(.=preceding::*)]">  
+        <citation type="CreativeWork">
+          <xsl:if test="./abcd:TitleCitation">
+            <name><xsl:value-of select="./abcd:TitleCitation"/></name>
+          </xsl:if>
+          <xsl:if test="./abcd:CitationDetail">
+            <description><xsl:value-of select="./abcd:CitationDetail"/></description>
+          </xsl:if>
+          <xsl:if test="./abcd:URI">
+            <identifier><xsl:value-of select="./abcd:URI"/></identifier>
+          </xsl:if>
+        </citation>
       </xsl:for-each>
       
       <xsl:for-each select="$taxon_name[not(.=preceding::*)]">  

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -109,6 +109,11 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
+                <SourceReference>
+                    <TitleCitation>Plants at Crater Road of Queen Elizabeth National Park, Uganda.</TitleCitation>
+                    <CitationDetail>Plant occurrences at Crater Road, Queen Elizabeth National Park, Uganda (April 1995 until March 1997). </CitationDetail>
+                    <URI>https://doi.org/10.34656/nkez-tt26.2</URI>
+                </SourceReference>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/3</RecordURI>
             </Unit>
             <Unit>
@@ -233,6 +238,11 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
+                <SourceReference>
+                    <TitleCitation>Plants at Crater Road of Queen Elizabeth National Park, Uganda.</TitleCitation>
+                    <CitationDetail>Plant occurrences at Crater Road, Queen Elizabeth National Park, Uganda (April 1995 until March 1997). </CitationDetail>
+                    <URI>https://doi.org/10.34656/nkez-tt26.2</URI>
+                </SourceReference>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/6</RecordURI>
             </Unit>
             <Unit>
@@ -299,6 +309,10 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
+                <SourceReference>
+                    <TitleCitation>Plants at Crater Road of Queen Elizabeth National Park, Uganda.</TitleCitation>
+                    <URI>https://doi.org/10.34656/nkez-tt26.2</URI>
+                </SourceReference>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/7</RecordURI>
             </Unit>
             <Unit>
@@ -365,6 +379,10 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
+                <SourceReference>
+                    <TitleCitation>Plants of Queen Elizabeth National Park, Uganda.</TitleCitation>
+                    <URI>https://doi.org/10.34656/nkez-tt26.2</URI>
+                </SourceReference>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/11</RecordURI>
             </Unit>
             <Unit>


### PR DESCRIPTION
#### Tickets
[#21]

#### Justification
Units may be based on publications. That's why it is useful to provide a feature to search for datasets that include such unit records. The information in _abcd:/Unit/SourceReference_ need to be mapped as [schema:CreativeWork](https://schema.org/CreativeWork) in the [schema:citation](https://schema.org/citation) property. The exact element mapping specification can be found in the linked ticket in more detail.

#### Code changes
XSLT file
- Added variable for citation.
- Mapping of TitleCitation, CitationDetail and URI.

XML file
- Added examples with different degrees of completeness and for testing (for example for duplicates).