### PR TITLE
[#27] Add mapping of various unit IDs

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -135,7 +135,6 @@ exclude-result-prefixes="xsl md panxslt set">
         </usageInfo>
       </xsl:for-each>
 
-    <!-- for each unit check if recordURI is a HTTP URL (contains a http). If so, use it as both identifier and url. If not, use the recordURI as identifier. -->
     <xsl:for-each select="$unit">
       <xsl:if test="./abcd:RecordURI">
         <about type="BioSample">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -33,6 +33,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="scope_taxonomic" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:TaxonomicTerms/abcd:TaxonomicTerm"></xsl:variable>
   <xsl:variable name="scope_geoecological" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:GeoecologicalTerms/*[self::abcd:GeoecologicalTerm or self::abcd:GeoEcologicalTerm]"></xsl:variable>
   
+  <xsl:variable name="unit" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit"></xsl:variable>
   <xsl:variable name="recordbasis" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordBasis"></xsl:variable>
   <xsl:variable name="coordinates" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
   <xsl:variable name="country" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
@@ -42,7 +43,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  
+  <xsl:variable name="record_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordURI"></xsl:variable>
 
         
 
@@ -133,6 +134,19 @@ exclude-result-prefixes="xsl md panxslt set">
           </xsl:if>
         </usageInfo>
       </xsl:for-each>
+
+    <!-- for each unit check if recordURI is a HTTP URL (contains a http). If so, use it as both identifier and url. If not, use the recordURI as identifier. -->
+    <xsl:for-each select="$unit">
+      <xsl:if test="./abcd:RecordURI">
+        <about type="BioSample">
+          <xsl:variable name="record_uri" select="./abcd:RecordURI"></xsl:variable>
+          <identifier><xsl:value-of select="$record_uri"/></identifier>
+          <xsl:if test="contains($record_uri,'http')">
+            <url><xsl:value-of select="$record_uri"/></url>
+          </xsl:if>
+        </about>
+      </xsl:if>
+    </xsl:for-each>
       
     <xsl:for-each select="$country[not(.=preceding::*)]">  
       <spatialCoverage type="Country">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -140,6 +140,21 @@ exclude-result-prefixes="xsl md panxslt set">
         <about type="BioSample">
           <xsl:variable name="record_uri" select="./abcd:RecordURI"></xsl:variable>
           <identifier><xsl:value-of select="$record_uri"/></identifier>
+          <xsl:if test="./abcd:SourceInstitutionID">
+            <identifier><xsl:value-of select="./abcd:SourceInstitutionID"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:SourceID">
+            <identifier><xsl:value-of select="./abcd:SourceID"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:UnitID">
+            <identifier><xsl:value-of select="./abcd:UnitID"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:UnitIDNumeric">
+            <identifier><xsl:value-of select="./abcd:UnitIDNumeric"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:UnitGUID">
+            <identifier><xsl:value-of select="./abcd:UnitGUID"/></identifier>
+          </xsl:if>
           <xsl:if test="contains($record_uri,'http')">
             <url><xsl:value-of select="$record_uri"/></url>
           </xsl:if>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -233,7 +233,7 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
-                <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/6</RecordURI>
+                <RecordURI>B/HoffmannPlants/6</RecordURI>
             </Unit>
             <Unit>
                 <SourceInstitutionID>B</SourceInstitutionID>


### PR DESCRIPTION
#### Tickets
[#27]

#### Justification
Filtering datasets for diverse unit-related identifiers must be enabled for the search as it is likely that users search for datasets containing given IDs. For this purpose, the following ABCD elements need to be mapped:
- _/DataSets/DataSet/Units/Unit/SourceInstitutionID_
- _/DataSets/DataSet/Units/Unit/SourceID_
- _/DataSets/DataSet/Units/Unit/UnitID_
- _/DataSets/DataSet/Units/Unit/UnitIDNumeric_
- _/DataSets/DataSet/Units/Unit/UnitGUID_
These identifiers are mapped to [schema:identifier](https://schema.org/identifier) of [bioschemas:BioSample](https://bioschemas.org/profiles/BioSample/0.1-DRAFT-2019_11_12) entities in schema:about of a [schema:Dataset](https://schema.org/Dataset). 

#### Code changes
XSLT file
- Added variable for "Unit" information.
- Mapping as specified above.

XML file
- Example update.
