### PR TITLE
[#29] Add collectors field number mapping

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -155,6 +155,9 @@ exclude-result-prefixes="xsl md panxslt set">
           <xsl:if test="./abcd:UnitGUID">
             <identifier><xsl:value-of select="./abcd:UnitGUID"/></identifier>
           </xsl:if>
+          <xsl:if test="./abcd:CollectorsFieldNumber">
+            <identifier><xsl:value-of select="./abcd:CollectorsFieldNumber"/></identifier>
+          </xsl:if>
           <xsl:if test="contains($record_uri,'http')">
             <url><xsl:value-of select="$record_uri"/></url>
           </xsl:if>

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -135,7 +135,6 @@ exclude-result-prefixes="xsl md panxslt set">
         </usageInfo>
       </xsl:for-each>
 
-    <!-- for each unit check if recordURI is a HTTP URL (contains a http). If so, use it as both identifier and url. If not, use the recordURI as identifier. -->
     <xsl:for-each select="$unit">
       <xsl:if test="./abcd:RecordURI">
         <about type="BioSample">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -33,6 +33,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="scope_taxonomic" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:TaxonomicTerms/abcd:TaxonomicTerm"></xsl:variable>
   <xsl:variable name="scope_geoecological" select="/abcd:DataSets/abcd:DataSet/abcd:Metadata/abcd:Scope/abcd:GeoecologicalTerms/*[self::abcd:GeoecologicalTerm or self::abcd:GeoEcologicalTerm]"></xsl:variable>
   
+  <xsl:variable name="unit" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit"></xsl:variable>
   <xsl:variable name="recordbasis" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordBasis"></xsl:variable>
   <xsl:variable name="coordinates" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteCoordinateSets/abcd:SiteCoordinates/abcd:CoordinatesLatLong"></xsl:variable>
   <xsl:variable name="country" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Country/abcd:Name"></xsl:variable>
@@ -42,7 +43,7 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  
+  <xsl:variable name="record_uri" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:RecordURI"></xsl:variable>
 
         
 
@@ -133,6 +134,19 @@ exclude-result-prefixes="xsl md panxslt set">
           </xsl:if>
         </usageInfo>
       </xsl:for-each>
+
+    <!-- for each unit check if recordURI is a HTTP URL (contains a http). If so, use it as both identifier and url. If not, use the recordURI as identifier. -->
+    <xsl:for-each select="$unit">
+      <xsl:if test="./abcd:RecordURI">
+        <about type="BioSample">
+          <xsl:variable name="record_uri" select="./abcd:RecordURI"></xsl:variable>
+          <identifier><xsl:value-of select="$record_uri"/></identifier>
+          <xsl:if test="contains($record_uri,'http')">
+            <url><xsl:value-of select="$record_uri"/></url>
+          </xsl:if>
+        </about>
+      </xsl:if>
+    </xsl:for-each>
       
     <xsl:for-each select="$country[not(.=preceding::*)]">  
       <spatialCoverage type="Country">

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -140,6 +140,21 @@ exclude-result-prefixes="xsl md panxslt set">
         <about type="BioSample">
           <xsl:variable name="record_uri" select="./abcd:RecordURI"></xsl:variable>
           <identifier><xsl:value-of select="$record_uri"/></identifier>
+          <xsl:if test="./abcd:SourceInstitutionID">
+            <identifier><xsl:value-of select="./abcd:SourceInstitutionID"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:SourceID">
+            <identifier><xsl:value-of select="./abcd:SourceID"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:UnitID">
+            <identifier><xsl:value-of select="./abcd:UnitID"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:UnitIDNumeric">
+            <identifier><xsl:value-of select="./abcd:UnitIDNumeric"/></identifier>
+          </xsl:if>
+          <xsl:if test="./abcd:UnitGUID">
+            <identifier><xsl:value-of select="./abcd:UnitGUID"/></identifier>
+          </xsl:if>
           <xsl:if test="contains($record_uri,'http')">
             <url><xsl:value-of select="$record_uri"/></url>
           </xsl:if>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -233,7 +233,7 @@
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
-                <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/6</RecordURI>
+                <RecordURI>B/HoffmannPlants/6</RecordURI>
             </Unit>
             <Unit>
                 <SourceInstitutionID>B</SourceInstitutionID>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -437,6 +437,7 @@
                 <SourceInstitutionID>B</SourceInstitutionID>
                 <SourceID>HoffmannPlants</SourceID>
                 <UnitID>16</UnitID>
+                <CollectorsFieldNumber>160</CollectorsFieldNumber>
                 <Identifications>
                     <Identification>
                         <Result>
@@ -503,6 +504,7 @@
                 <SourceInstitutionID>B</SourceInstitutionID>
                 <SourceID>HoffmannPlants</SourceID>
                 <UnitID>17</UnitID>
+                <CollectorsFieldNumber>170</CollectorsFieldNumber>
                 <Identifications>
                     <Identification>
                         <Result>


### PR DESCRIPTION
#### Tickets
[#29]

#### Justification
A user may have knowledge of a particular field number of a unit that has been assigned by the collector. It is therefore possible for this user to search for datasets that contain units comprising this given number in the field _abcd:./CollectorsFieldNumber_. The mapping follows that of other unit-related identifiers (see #27).

#### Code changes
XSLT file
- Add mapping of collectors field number in identifier mapping part.

XML file
- Example update.
