### PR TITLE
[#17] Add mapping of measurements

### DIFF
--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -540,31 +540,36 @@ exclude-result-prefixes="xsl md panxslt set">
       </xsl:for-each>
 
       <!-- Site measurements -->
-      <xsl:for-each select="$site_measure/abcd:SiteMeasurementOrFact[not(.=preceding::*)]">
+      <xsl:variable name="parameters">
+        <xsl:for-each select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteMeasurementsOrFacts/abcd:SiteMeasurementOrFact/abcd:MeasurementOrFactAtomised/abcd:Parameter[not(.=preceding::*)]">
+          <parameter><xsl:value-of select="."/></parameter>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:for-each select="$parameters/parameter">
+        <xsl:variable name="param" select="."/>
+        <xsl:variable name="minValue">
+          <xsl:for-each select="$site_measure/abcd:SiteMeasurementOrFact[abcd:MeasurementOrFactAtomised/abcd:Parameter=$param]/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and number(.)]">
+            <xsl:sort select="." data-type="number" order="ascending"/>
+            <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:variable name="maxValue">
+          <xsl:for-each select="$site_measure/abcd:SiteMeasurementOrFact[abcd:MeasurementOrFactAtomised/abcd:Parameter=$param]/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and number(.)]">
+            <xsl:sort select="." data-type="number" order="descending"/>
+            <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
         <variableMeasured type="PropertyValue">
-          <xsl:if test="./abcd:MeasurementOrFactText">
-            <name><xsl:value-of select="./abcd:MeasurementOrFactText"/></name>
-          </xsl:if>
-          <xsl:if test="./abcd:MeasurementOrFactAtomised">
-            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Parameter">
-              <name><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/></name>
-            </xsl:if>
-            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Method">
-              <measurementTechnique><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Method"/></measurementTechnique>
-            </xsl:if>
-            <xsl:choose>
-              <xsl:when test="(./abcd:MeasurementOrFactAtomised/abcd:UpperValue) and not(./abcd:MeasurementOrFactAtomised/abcd:LowerValue = ./abcd:MeasurementOrFactAtomised/abcd:UpperValue)">
-                <maxValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UpperValue"/></maxValue>
-                <minValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></minValue>
-              </xsl:when>
-              <xsl:otherwise>
-                <value xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
-              </xsl:otherwise>
-            </xsl:choose>
-            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement">
-              <unitText><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement"/></unitText>
-            </xsl:if>
-          </xsl:if>
+          <name><xsl:value-of select="$param"/></name>
+          <xsl:choose>
+            <xsl:when test="$minValue = $maxValue">
+              <value xsi:type="xs:double"><xsl:value-of select="$minValue"/></value>
+            </xsl:when>
+            <xsl:otherwise>
+              <minValue xsi:type="xs:double"><xsl:value-of select="$minValue"/></minValue>
+              <maxValue xsi:type="xs:double"><xsl:value-of select="$maxValue"/></maxValue>
+            </xsl:otherwise>
+          </xsl:choose>
         </variableMeasured>
       </xsl:for-each>
       

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -42,7 +42,12 @@ exclude-result-prefixes="xsl md panxslt set">
   <xsl:variable name="biostratigraphic" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Stratigraphy/abcd:BiostratigraphicTerms/abcd:BiostratigraphicTerm/abcd:Term"></xsl:variable>
   <xsl:variable name="taxon_name" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:ScientificName/abcd:FullScientificNameString"></xsl:variable>
   <xsl:variable name="higher_taxon" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Identifications/abcd:Identification/abcd:Result/abcd:TaxonIdentified/abcd:HigherTaxa/abcd:HigherTaxon/abcd:HigherTaxonName"></xsl:variable>
-  
+  <xsl:variable name="altitude" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Altitude"></xsl:variable>
+  <xsl:variable name="biotope_measure" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Biotope/abcd:MeasurementsOrFacts"></xsl:variable>
+  <xsl:variable name="depth" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Depth"></xsl:variable>
+  <xsl:variable name="height" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Height"></xsl:variable>
+  <xsl:variable name="site_measure" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:SiteMeasurementsOrFacts"></xsl:variable>
+  <xsl:variable name="unit_measure" select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:MeasurementsOrFacts"></xsl:variable>
 
         
 
@@ -411,9 +416,169 @@ exclude-result-prefixes="xsl md panxslt set">
           <name><xsl:value-of select="$dataset_contributors"/></name>
         </contributor>
       </xsl:if>
+
+      <!-- variableMeasured -->
+      <!-- Altitude -->
+      <xsl:variable name="minAltitude">
+        <xsl:for-each select="$altitude/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and (not(../abcd:UnitOfMeasurement) or ../abcd:UnitOfMeasurement = 'm')]">
+          <xsl:sort select="." data-type="number" order="ascending"/>
+          <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:variable name="maxAltitude">
+        <xsl:for-each select="$altitude/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and (not(../abcd:UnitOfMeasurement) or ../abcd:UnitOfMeasurement = 'm')]">
+          <xsl:sort select="." data-type="number" order="descending"/>
+          <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+      <variableMeasured type="PropertyValue">
+        <name>Elevation</name>
+        <propertyID>https://schema.org/elevation</propertyID>
+        <xsl:choose>
+          <xsl:when test="$minAltitude = $maxAltitude">
+            <value xsi:type="xs:double"><xsl:value-of select="$minAltitude"/></value>
+            <unitText>m</unitText>
+          </xsl:when>
+          <xsl:otherwise>
+            <minValue xsi:type="xs:double"><xsl:value-of select="$minAltitude"/></minValue>
+            <xsl:if test="$maxAltitude"><maxValue xsi:type="xs:double"><xsl:value-of select="$maxAltitude"/></maxValue></xsl:if>
+            <unitText>m</unitText>
+          </xsl:otherwise>
+        </xsl:choose>
+      </variableMeasured>
+
+      <!-- Depth -->
+      <xsl:variable name="minDepth">
+        <xsl:for-each select="$depth/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and (not(../abcd:UnitOfMeasurement) or ../abcd:UnitOfMeasurement = 'm')]">
+          <xsl:sort select="." data-type="number" order="ascending"/>
+          <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:variable name="maxDepth">
+        <xsl:for-each select="$depth/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and (not(../abcd:UnitOfMeasurement) or ../abcd:UnitOfMeasurement = 'm')]">
+          <xsl:sort select="." data-type="number" order="descending"/>
+          <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+        </xsl:for-each>
+      </xsl:variable>
+      <variableMeasured type="PropertyValue">
+        <name>Depth</name>
+        <propertyID>https://schema.org/depth</propertyID>
+        <xsl:choose>
+          <xsl:when test="$minDepth = $maxDepth">
+            <value xsi:type="xs:double"><xsl:value-of select="$minDepth"/></value>
+            <unitText>m</unitText>
+          </xsl:when>
+          <xsl:otherwise>
+            <minValue xsi:type="xs:double"><xsl:value-of select="$minDepth"/></minValue>
+            <xsl:if test="$maxDepth"><maxValue xsi:type="xs:double"><xsl:value-of select="$maxDepth"/></maxValue></xsl:if>
+            <unitText>m</unitText>
+          </xsl:otherwise>
+        </xsl:choose>
+      </variableMeasured>
+
+      <!-- Biotope -->
+      <xsl:for-each select="$biotope_measure/abcd:MeasurementOrFact[not(.=preceding::*)]">
+        <variableMeasured type="PropertyValue">
+          <xsl:if test="./abcd:MeasurementOrFactText">
+            <name><xsl:value-of select="./abcd:MeasurementOrFactText"/></name>
+          </xsl:if>
+          <xsl:if test="./abcd:MeasurementOrFactAtomised">
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Parameter">
+              <name><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/></name>
+            </xsl:if>
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Method">
+              <measurementTechnique><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Method"/></measurementTechnique>
+            </xsl:if>
+            <xsl:choose>
+              <xsl:when test="(./abcd:MeasurementOrFactAtomised/abcd:UpperValue) and not(./abcd:MeasurementOrFactAtomised/abcd:LowerValue = ./abcd:MeasurementOrFactAtomised/abcd:UpperValue)">
+                <maxValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UpperValue"/></maxValue>
+                <minValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></minValue>
+              </xsl:when>
+              <xsl:otherwise>
+                <value xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement">
+              <unitText><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement"/></unitText>
+            </xsl:if>
+          </xsl:if>
+        </variableMeasured>
+      </xsl:for-each>
+
+      <!-- Unit measurements -->
+      <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact[not(.=preceding::*)]">
+        <variableMeasured type="PropertyValue">
+          <xsl:if test="./abcd:MeasurementOrFactText">
+            <name><xsl:value-of select="./abcd:MeasurementOrFactText"/></name>
+          </xsl:if>
+          <xsl:if test="./abcd:MeasurementOrFactAtomised">
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Parameter">
+              <name><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/></name>
+            </xsl:if>
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Method">
+              <measurementTechnique><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Method"/></measurementTechnique>
+            </xsl:if>
+            <xsl:choose>
+              <xsl:when test="(./abcd:MeasurementOrFactAtomised/abcd:UpperValue) and not(./abcd:MeasurementOrFactAtomised/abcd:LowerValue = ./abcd:MeasurementOrFactAtomised/abcd:UpperValue)">
+                <maxValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UpperValue"/></maxValue>
+                <minValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></minValue>
+              </xsl:when>
+              <xsl:otherwise>
+                <!-- TODO: Check if LowerValue is a number -->
+                <xsl:choose>
+                  <xsl:when test="number(./abcd:MeasurementOrFactAtomised/abcd:LowerValue)">
+                    <value xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <!-- TODO: extract numbers from string. If there are multiple numbers, add multiple value elements -->
+                    <xsl:for-each select="for $n in tokenize(./abcd:MeasurementOrFactAtomised/abcd:LowerValue, '[^0-9]+' )[.] return xs:double($n)">
+                      <value xsi:type="xs:double"><xsl:value-of select="."/></value>
+                    </xsl:for-each>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement">
+              <unitText><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement"/></unitText>
+            </xsl:if>
+          </xsl:if>
+        </variableMeasured>
+      </xsl:for-each>
+
+      <!-- Site measurements -->
+      <xsl:for-each select="$site_measure/abcd:SiteMeasurementOrFact[not(.=preceding::*)]">
+        <variableMeasured type="PropertyValue">
+          <xsl:if test="./abcd:MeasurementOrFactText">
+            <name><xsl:value-of select="./abcd:MeasurementOrFactText"/></name>
+          </xsl:if>
+          <xsl:if test="./abcd:MeasurementOrFactAtomised">
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Parameter">
+              <name><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/></name>
+            </xsl:if>
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Method">
+              <measurementTechnique><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Method"/></measurementTechnique>
+            </xsl:if>
+            <xsl:choose>
+              <xsl:when test="(./abcd:MeasurementOrFactAtomised/abcd:UpperValue) and not(./abcd:MeasurementOrFactAtomised/abcd:LowerValue = ./abcd:MeasurementOrFactAtomised/abcd:UpperValue)">
+                <maxValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UpperValue"/></maxValue>
+                <minValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></minValue>
+              </xsl:when>
+              <xsl:otherwise>
+                <value xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement">
+              <unitText><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement"/></unitText>
+            </xsl:if>
+          </xsl:if>
+        </variableMeasured>
+      </xsl:for-each>
+      
      <!-- TODO:
        - Gathering Agents as contributors?
-       - variableMeasured
+       - variableMeasured:
+          - Identify variants with multiple values in the same element (e.g. in LowerValue)
+          - Add examples
      -->
     </jsonld>
   </xsl:template>

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -477,31 +477,37 @@ exclude-result-prefixes="xsl md panxslt set">
       </variableMeasured>
 
       <!-- Biotope -->
-      <xsl:for-each select="$biotope_measure/abcd:MeasurementOrFact[not(.=preceding::*)]">
+      <xsl:variable name="parameters">
+        <xsl:for-each select="/abcd:DataSets/abcd:DataSet/abcd:Units/abcd:Unit/abcd:Gathering/abcd:Biotope/abcd:MeasurementsOrFacts/abcd:MeasurementOrFact/abcd:MeasurementOrFactAtomised/abcd:Parameter[not(.=preceding::*)]">
+          <parameter><xsl:value-of select="."/></parameter>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:for-each select="$parameters/parameter">
+        <test><xsl:value-of select="."/></test>
+        <xsl:variable name="param" select="."/>
+        <xsl:variable name="minValue">
+          <xsl:for-each select="$biotope_measure/abcd:MeasurementOrFact[abcd:MeasurementOrFactAtomised/abcd:Parameter=$param]/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and number(.)]">
+            <xsl:sort select="." data-type="number" order="ascending"/>
+            <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:variable name="maxValue">
+          <xsl:for-each select="$biotope_measure/abcd:MeasurementOrFact[abcd:MeasurementOrFactAtomised/abcd:Parameter=$param]/abcd:MeasurementOrFactAtomised/*[(self::abcd:LowerValue or self::abcd:UpperValue) and number(.)]">
+            <xsl:sort select="." data-type="number" order="descending"/>
+            <xsl:if test="position() = 1"><xsl:value-of select="."/></xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
         <variableMeasured type="PropertyValue">
-          <xsl:if test="./abcd:MeasurementOrFactText">
-            <name><xsl:value-of select="./abcd:MeasurementOrFactText"/></name>
-          </xsl:if>
-          <xsl:if test="./abcd:MeasurementOrFactAtomised">
-            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Parameter">
-              <name><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/></name>
-            </xsl:if>
-            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:Method">
-              <measurementTechnique><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:Method"/></measurementTechnique>
-            </xsl:if>
-            <xsl:choose>
-              <xsl:when test="(./abcd:MeasurementOrFactAtomised/abcd:UpperValue) and not(./abcd:MeasurementOrFactAtomised/abcd:LowerValue = ./abcd:MeasurementOrFactAtomised/abcd:UpperValue)">
-                <maxValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UpperValue"/></maxValue>
-                <minValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></minValue>
-              </xsl:when>
-              <xsl:otherwise>
-                <value xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
-              </xsl:otherwise>
-            </xsl:choose>
-            <xsl:if test="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement">
-              <unitText><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:UnitOfMeasurement"/></unitText>
-            </xsl:if>
-          </xsl:if>
+          <name><xsl:value-of select="$param"/></name>
+          <xsl:choose>
+            <xsl:when test="$minValue = $maxValue">
+              <value xsi:type="xs:double"><xsl:value-of select="$minValue"/></value>
+            </xsl:when>
+            <xsl:otherwise>
+              <minValue xsi:type="xs:double"><xsl:value-of select="$minValue"/></minValue>
+              <maxValue xsi:type="xs:double"><xsl:value-of select="$maxValue"/></maxValue>
+            </xsl:otherwise>
+          </xsl:choose>
         </variableMeasured>
       </xsl:for-each>
 

--- a/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
+++ b/transformations/abcd2bioschemas/abcd2bioschemas-xml.xslt
@@ -506,7 +506,49 @@ exclude-result-prefixes="xsl md panxslt set">
       </xsl:for-each>
 
       <!-- Unit measurements -->
-      <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact[not(.=preceding::*)]">
+      <!-- TODO: Add UpperValue and LowerValue where it is missing. Number check -->
+      <xsl:variable name="minima">
+        <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact">
+          <xsl:variable name="parameter" select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/>
+          <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact[abcd:MeasurementOrFactAtomised/abcd:Parameter = $parameter]">
+            <xsl:sort select="abcd:MeasurementOrFactAtomised/abcd:LowerValue" data-type="number" order="ascending"/>
+            <xsl:if test="position() = 1">
+              <min>
+                <parameter><xsl:value-of select="$parameter"/></parameter>
+                <value><xsl:value-of select="abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
+              </min>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:for-each>
+      </xsl:variable>
+      <xsl:variable name="maxima">
+        <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact">
+          <xsl:variable name="parameter" select="./abcd:MeasurementOrFactAtomised/abcd:Parameter"/>
+          <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact[abcd:MeasurementOrFactAtomised/abcd:Parameter = $parameter]">
+            <xsl:sort select="abcd:MeasurementOrFactAtomised/abcd:UpperValue" data-type="number" order="descending"/>
+            <xsl:if test="position() = 1">
+              <max>
+                <parameter><xsl:value-of select="$parameter"/></parameter>
+                <value><xsl:value-of select="abcd:MeasurementOrFactAtomised/abcd:UpperValue"/></value>
+              </max>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:for-each>  
+      </xsl:variable>
+      <!-- TODO: Add maxima. Update output. -->
+      <xsl:if test="$minima/min">
+        <!-- Remove duplicates -->
+        <xsl:for-each select="$minima/min">
+          <xsl:if test="not(.=preceding::*)">
+            <variableMeasured type="PropertyValue">
+              <name><xsl:value-of select="parameter"/></name>
+              <value xsi:type="xs:double"><xsl:value-of select="value"/></value>
+            </variableMeasured>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:if>
+
+      <!-- <xsl:for-each select="$unit_measure/abcd:MeasurementOrFact[not(.=preceding::*)]">
         <variableMeasured type="PropertyValue">
           <xsl:if test="./abcd:MeasurementOrFactText">
             <name><xsl:value-of select="./abcd:MeasurementOrFactText"/></name>
@@ -524,13 +566,13 @@ exclude-result-prefixes="xsl md panxslt set">
                 <minValue xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></minValue>
               </xsl:when>
               <xsl:otherwise>
-                <!-- TODO: Check if LowerValue is a number -->
+                TODO: Check if LowerValue is a number
                 <xsl:choose>
                   <xsl:when test="number(./abcd:MeasurementOrFactAtomised/abcd:LowerValue)">
                     <value xsi:type="xs:double"><xsl:value-of select="./abcd:MeasurementOrFactAtomised/abcd:LowerValue"/></value>
                   </xsl:when>
                   <xsl:otherwise>
-                    <!-- TODO: extract numbers from string. If there are multiple numbers, add multiple value elements -->
+                    TODO: extract numbers from string. If there are multiple numbers, add multiple value elements
                     <xsl:for-each select="for $n in tokenize(./abcd:MeasurementOrFactAtomised/abcd:LowerValue, '[^0-9]+' )[.] return xs:double($n)">
                       <value xsi:type="xs:double"><xsl:value-of select="."/></value>
                     </xsl:for-each>
@@ -543,7 +585,7 @@ exclude-result-prefixes="xsl md panxslt set">
             </xsl:if>
           </xsl:if>
         </variableMeasured>
-      </xsl:for-each>
+      </xsl:for-each> -->
 
       <!-- Site measurements -->
       <xsl:for-each select="$site_measure/abcd:SiteMeasurementOrFact[not(.=preceding::*)]">

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -1669,6 +1669,14 @@
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
                 </Gathering>
+                <MeasurementsOrFacts>
+                    <MeasurementOrFact>
+                        <MeasurementOrFactAtomised>
+                            <Parameter>Weight</Parameter>
+                            <LowerValue>3</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </MeasurementOrFact>
+                </MeasurementsOrFacts>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/114</RecordURI>
             </Unit>
             <Unit>
@@ -1727,6 +1735,14 @@
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
                 </Gathering>
+                <MeasurementsOrFacts>
+                    <MeasurementOrFact>
+                        <MeasurementOrFactAtomised>
+                            <Parameter>Weight</Parameter>
+                            <LowerValue>2</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </MeasurementOrFact>
+                </MeasurementsOrFacts>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/117</RecordURI>
             </Unit>
             <Unit>
@@ -1785,6 +1801,14 @@
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
                 </Gathering>
+                <MeasurementsOrFacts>
+                    <MeasurementOrFact>
+                        <MeasurementOrFactAtomised>
+                            <Parameter>Weight</Parameter>
+                            <LowerValue>5</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </MeasurementOrFact>
+                </MeasurementsOrFacts>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/119</RecordURI>
             </Unit>
             <Unit>
@@ -1843,6 +1867,14 @@
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
                 </Gathering>
+                <MeasurementsOrFacts>
+                    <MeasurementOrFact>
+                        <MeasurementOrFactAtomised>
+                            <Parameter>Area</Parameter>
+                            <LowerValue>1</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </MeasurementOrFact>
+                </MeasurementsOrFacts>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/120</RecordURI>
             </Unit>
             <Unit>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -1693,6 +1693,17 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Biotope>
+                        <MeasurementsOrFacts>
+                            <MeasurementOrFact>
+                                <MeasurementOrFactAtomised>
+                                    <Parameter>Salinity</Parameter>
+                                    <LowerValue>0.1</LowerValue>
+                                    <UpperValue>0.2</UpperValue>
+                                </MeasurementOrFactAtomised>
+                            </MeasurementOrFact>
+                        </MeasurementsOrFacts>
+                    </Biotope>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -1759,6 +1770,16 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Biotope>
+                        <MeasurementsOrFacts>
+                            <MeasurementOrFact>
+                                <MeasurementOrFactAtomised>
+                                    <Parameter>ph value</Parameter>
+                                    <LowerValue>6.5</LowerValue>
+                                </MeasurementOrFactAtomised>
+                            </MeasurementOrFact>
+                        </MeasurementsOrFacts>
+                    </Biotope>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -109,7 +109,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>40--100</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -245,7 +245,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>100</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -316,7 +316,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>100--150</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -387,7 +387,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>50--150</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -458,7 +458,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>100--200</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -524,7 +524,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>50</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -595,7 +595,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>30, 250</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -1247,7 +1247,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>15--20</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -1321,7 +1321,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>86, 100</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -1395,7 +1395,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>110, 120</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -1461,7 +1461,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>87--150</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -1537,7 +1537,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>100--140</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
@@ -1805,8 +1805,8 @@
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
                             <Parameter>Weight</Parameter>
-                            <LowerValue>3</LowerValue>
-                            <UpperValue>8</UpperValue>
+                            <LowerValue>1</LowerValue>
+                            <UpperValue>7</UpperValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
@@ -1938,7 +1938,7 @@
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
                             <Parameter>Weight</Parameter>
-                            <LowerValue>5</LowerValue>
+                            <LowerValue>10</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
@@ -2235,7 +2235,7 @@
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
-                            <Method>height of plant or bush in cm</Method>
+                            <Parameter>height of plant or bush in cm</Parameter>
                             <LowerValue>11</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -100,6 +100,11 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Altitude>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>1250</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </Altitude>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -166,6 +171,11 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Altitude>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>950</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </Altitude>
                 </Gathering>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/4</RecordURI>
             </Unit>
@@ -224,6 +234,13 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Altitude>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>2500</LowerValue>
+                            <UpperValue>2900</UpperValue>
+                            <UnitOfMeasurement>m</UnitOfMeasurement>
+                        </MeasurementOrFactAtomised>
+                    </Altitude>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -290,6 +307,11 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Altitude>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>2600</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </Altitude>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -356,6 +378,11 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Altitude>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>200</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </Altitude>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -422,6 +449,11 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Altitude>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>300</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </Altitude>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -554,6 +586,11 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Depth>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>0.5</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </Depth>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -620,6 +657,12 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Depth>
+                        <MeasurementOrFactAtomised>
+                            <LowerValue>1.2</LowerValue>
+                            <UpperValue>1.5</UpperValue>
+                        </MeasurementOrFactAtomised>
+                    </Depth>
                 </Gathering>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/26</RecordURI>
             </Unit>
@@ -1266,6 +1309,14 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <SiteMeasurementsOrFacts>
+                        <SiteMeasurementOrFact>
+                            <MeasurementOrFactAtomised>
+                                <Parameter>Temperature</Parameter>
+                                <LowerValue>20</LowerValue>
+                            </MeasurementOrFactAtomised>
+                        </SiteMeasurementOrFact>
+                    </SiteMeasurementsOrFacts>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -1332,6 +1383,14 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <SiteMeasurementsOrFacts>
+                        <SiteMeasurementOrFact>
+                            <MeasurementOrFactAtomised>
+                                <Parameter>Temperature</Parameter>
+                                <LowerValue>20</LowerValue>
+                            </MeasurementOrFactAtomised>
+                        </SiteMeasurementOrFact>
+                    </SiteMeasurementsOrFacts>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -1464,6 +1523,16 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Biotope>
+                        <MeasurementsOrFacts>
+                            <MeasurementOrFact>
+                                <MeasurementOrFactAtomised>
+                                    <Parameter>Salinity</Parameter>
+                                    <LowerValue>0.1</LowerValue>
+                                </MeasurementOrFactAtomised>
+                            </MeasurementOrFact>
+                        </MeasurementsOrFacts>
+                    </Biotope>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -1530,6 +1599,17 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <Biotope>
+                        <MeasurementsOrFacts>
+                            <MeasurementOrFact>
+                                <MeasurementOrFactAtomised>
+                                    <Parameter>Vegetation Height</Parameter>
+                                    <LowerValue>10</LowerValue>
+                                    <UnitOfMeasurement>cm</UnitOfMeasurement>
+                                </MeasurementOrFactAtomised>
+                            </MeasurementOrFact>
+                        </MeasurementsOrFacts>
+                    </Biotope>
                 </Gathering>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/113</RecordURI>
             </Unit>
@@ -2181,7 +2261,7 @@
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
                             <Method>height of plant or bush in cm</Method>
-                            <LowerValue>34--64</LowerValue>
+                            <LowerValue>0.01--1064</LowerValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -1457,6 +1457,14 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <SiteMeasurementsOrFacts>
+                        <SiteMeasurementOrFact>
+                            <MeasurementOrFactAtomised>
+                                <Parameter>Temperature</Parameter>
+                                <LowerValue>23</LowerValue>
+                            </MeasurementOrFactAtomised>
+                        </SiteMeasurementOrFact>
+                    </SiteMeasurementsOrFacts>
                 </Gathering>
                 <MeasurementsOrFacts>
                     <MeasurementOrFact>
@@ -1523,6 +1531,14 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <SiteMeasurementsOrFacts>
+                        <SiteMeasurementOrFact>
+                            <MeasurementOrFactAtomised>
+                                <Parameter>Temperature</Parameter>
+                                <LowerValue>18</LowerValue>
+                            </MeasurementOrFactAtomised>
+                        </SiteMeasurementOrFact>
+                    </SiteMeasurementsOrFacts>
                     <Biotope>
                         <MeasurementsOrFacts>
                             <MeasurementOrFact>
@@ -1599,6 +1615,15 @@
                         <Name> Uganda</Name>
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
+                    <SiteMeasurementsOrFacts>
+                        <SiteMeasurementOrFact>
+                            <MeasurementOrFactAtomised>
+                                <Parameter>Temperature</Parameter>
+                                <LowerValue>19</LowerValue>
+                                <UpperValue>25</UpperValue>
+                            </MeasurementOrFactAtomised>
+                        </SiteMeasurementOrFact>
+                    </SiteMeasurementsOrFacts>
                     <Biotope>
                         <MeasurementsOrFacts>
                             <MeasurementOrFact>

--- a/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
+++ b/transformations/abcd2bioschemas/example_files/HoffmannPlantsV3.xml
@@ -1805,7 +1805,8 @@
                     <MeasurementOrFact>
                         <MeasurementOrFactAtomised>
                             <Parameter>Weight</Parameter>
-                            <LowerValue>5</LowerValue>
+                            <LowerValue>3</LowerValue>
+                            <UpperValue>8</UpperValue>
                         </MeasurementOrFactAtomised>
                     </MeasurementOrFact>
                 </MeasurementsOrFacts>
@@ -1933,6 +1934,14 @@
                         <ISO3166Code>UG </ISO3166Code>
                     </Country>
                 </Gathering>
+                <MeasurementsOrFacts>
+                    <MeasurementOrFact>
+                        <MeasurementOrFactAtomised>
+                            <Parameter>Weight</Parameter>
+                            <LowerValue>5</LowerValue>
+                        </MeasurementOrFactAtomised>
+                    </MeasurementOrFact>
+                </MeasurementsOrFacts>
                 <RecordURI>https://data-rebind.bgbm.org/gfbio/biocase/page/B/HoffmannPlants/121</RecordURI>
             </Unit>
             <Unit>


### PR DESCRIPTION
#### Tickets
[#17]

#### Justification
abcd:MeasurementOrFactAtomised contains quantitative and descriptive data that relate to a specific unit and may be suitable for being provided for the dataset search. However, multiple measurements of the same parameter must be summarized (in schema:variableMeasured) to represent a range of values in the dataset. See #17 for mapped elements and more details.

#### Code changes
XSLT file
- Add mapping of different ABCD elements to variableMeasured.
- Check for units.
- Determine max and min values.

XML file
- Example update.
